### PR TITLE
Set cwd when executing Popen in Linux

### DIFF
--- a/Kulture.py
+++ b/Kulture.py
@@ -140,7 +140,7 @@ class KTerminalCommand():
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 subprocess.Popen(args, cwd=cwd, startupinfo=startupinfo)
             elif plat == 'linux':
-                subprocess.Popen(args)
+                subprocess.Popen(args, cwd=cwd)
             else:
                 subprocess.Popen(args, cwd=cwd)
 


### PR DESCRIPTION
I noticed that cwd was not set in Linux, so none of the K commands were executed in Sublime Text 3, since those could not find project.json. After setting cwd, all the K commands could be executed normally.

I was also tempted to remove the "else if", since after my change, it does the same as the "else" part, but I thought that maybe you might want to add other functionalities for linux in the future.
